### PR TITLE
allow carrying toddlers to shuttles, even if they are not downed

### DIFF
--- a/1.5/Source/Toddlers/HarmonyPatching.cs
+++ b/1.5/Source/Toddlers/HarmonyPatching.cs
@@ -146,6 +146,23 @@ namespace Toddlers
                     return pawn.Downed || ToddlerUtility.IsLiveToddler(pawn);
                 };
             }
+            else if (__originalMethod == typeof(TargetingParameters).GetMethod(nameof(TargetingParameters.ForShuttle)))
+            {
+                Predicate<TargetInfo> oldValidator = __result.validator;
+                __result.validator = delegate (TargetInfo targ)
+                {
+                    if (oldValidator(targ))
+                    {
+                        return true;
+                    }
+                    if (!targ.HasThing || !(targ.Thing is Pawn pawn))
+                    {
+                        return false;
+                    }
+                    // Allow loading toddlers even if not downed.
+                    return ToddlerUtility.IsLiveToddler(pawn);
+                };
+            }
         }
     }
 


### PR DESCRIPTION
Normally pawns are allowed to be carried to shuttles only if they are downed, but toddlers will not get on on their own, and it could take them ages even if they would.

(The quest requiring loading a baby into a shuttle is probably from the Orphanage and Daycare mod.)
