### PR TITLE
Mess when eating (#22)

### DIFF
--- a/1.5/Defs/Filth.xml
+++ b/1.5/Defs/Filth.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+<ThingDef ParentName="BaseFilth">
+	<defName>Toddlers_Filth_Mess</defName>
+	<label>mess</label>
+	<graphicData>
+		<texPath>Things/Filth/Spatter</texPath>
+		<color>(217, 205, 145, 180)</color>
+	</graphicData>
+	<filth>
+		<disappearsInDays>35~40</disappearsInDays>
+		<rainWashes>true</rainWashes>
+		<cleaningWorkToReduceThickness>50</cleaningWorkToReduceThickness>
+		<canFilthAttach>true</canFilthAttach>
+		<cleaningSound>Interact_CleanFilth_Fluid</cleaningSound>
+	</filth>
+</ThingDef>
+
+</Defs>

--- a/1.6/Defs/Filth.xml
+++ b/1.6/Defs/Filth.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+<ThingDef ParentName="BaseFilth">
+	<defName>Toddlers_Filth_Mess</defName>
+	<label>mess</label>
+	<graphicData>
+		<texPath>Things/Filth/Spatter</texPath>
+		<color>(217, 205, 145, 180)</color>
+	</graphicData>
+	<filth>
+		<disappearsInDays>35~40</disappearsInDays>
+		<rainWashes>true</rainWashes>
+		<cleaningWorkToReduceThickness>50</cleaningWorkToReduceThickness>
+		<canFilthAttach>true</canFilthAttach>
+		<cleaningSound>Interact_CleanFilth_Fluid</cleaningSound>
+	</filth>
+</ThingDef>
+
+</Defs>

--- a/1.6/Defs/Hediffs.xml
+++ b/1.6/Defs/Hediffs.xml
@@ -69,11 +69,23 @@
 		<li>
 			<label>inept</label>
 			<overrideTooltip>{0} still struggles with picking up and handling simple objects -- like food and clothes.</overrideTooltip>
+			<capMods>
+				<li>
+					<capacity>Manipulation</capacity>
+					<offset>-0.85</offset>
+				</li>
+			</capMods>
 		</li>
 		<li>
 			<label>clumsy</label>
 			<overrideTooltip>{0} is growing more capable. {PAWN_pronoun} can get food -- more or less -- into {PAWN_possessive} mouth and can undress. Putting clothes back on is more of a challenge.</overrideTooltip>
 			<minSeverity>0.3</minSeverity>
+			<capMods>
+				<li>
+					<capacity>Manipulation</capacity>
+					<offset>-0.55</offset>
+				</li>
+			</capMods>
 			<mentalStateGivers>
 				<li>
 					<mentalState>RemoveClothes</mentalState>
@@ -85,6 +97,12 @@
 			<label>confident</label>
 			<overrideTooltip>{0} has mastered most everyday manual tasks, and is eager to show off {PAWN_possessive} new capabilities.</overrideTooltip>
 			<minSeverity>0.6</minSeverity>
+			<capMods>
+				<li>
+					<capacity>Manipulation</capacity>
+					<offset>-0.25</offset>
+				</li>
+			</capMods>
 			<mentalStateGivers>
 				<li>
 					<mentalState>RemoveClothes</mentalState>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -15,6 +15,8 @@
 <SettingTooltipCareAboutFloorSleep>Pawns will return babies/toddlers to their cribs if they notice them sleeping on the floor.</SettingTooltipCareAboutFloorSleep>
 <SettingLabelFeedCapableToddlers>Pawns feed toddlers who could feed themselves</SettingLabelFeedCapableToddlers>
 <SettingTooltipFeedCapableToddlers>Pawns will feed toddlers even if they are able to feed themselves.</SettingTooltipFeedCapableToddlers>
+<SettingLabelFeedingMakesMess>Feeding makes mess</SettingLabelFeedingMakesMess>
+<SettingTooltipFeedingMakesMess>Toddlers feeding themselves or being fed makes mess (less in the latter case).</SettingTooltipFeedingMakesMess>
 <SettingLabelBabyTalk>Baby talk for toddlers</SettingLabelBabyTalk>
 <SettingTooltipBabyTalk>Whether toddler thoughts should be translated to "goo goo ba gee".</SettingTooltipBabyTalk>
 

--- a/Source/Toddlers/Feeding/FeedingUtility.cs
+++ b/Source/Toddlers/Feeding/FeedingUtility.cs
@@ -23,5 +23,16 @@ namespace Toddlers
             }
             return false;
         }
+
+        public static void TryMakeMessTick(Pawn feeder, Pawn baby, float filthFactor = 1)
+        {
+            float filthRate = baby.GetStatValue(StatDefOf.FilthRate, cacheStaleAfterTicks : 60)
+                / Math.Max(feeder.health.capacities.GetLevel(PawnCapacityDefOf.Manipulation), 0.1f);
+            filthRate *= filthFactor;
+            if (!(Rand.Value < filthRate * 0.005f))
+                return;
+            if (FilthMaker.TryMakeFilth(feeder.Position, feeder.Map, ThingDefOf.Filth_Trash, baby.LabelIndefinite(), 1))
+                FilthMonitor.Notify_FilthHumanGenerated();
+        }
     }
 }

--- a/Source/Toddlers/Feeding/FeedingUtility.cs
+++ b/Source/Toddlers/Feeding/FeedingUtility.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Verse;
+using UnityEngine;
 
 namespace Toddlers
 {
@@ -33,6 +34,21 @@ namespace Toddlers
                 return;
             if (FilthMaker.TryMakeFilth(feeder.Position, feeder.Map, ThingDefOf.Filth_Trash, baby.LabelIndefinite(), 1))
                 FilthMonitor.Notify_FilthHumanGenerated();
+            if (Toddlers_Mod.DBHLoaded)
+            {
+                if (Patch_DBH.babyHygiene)
+                {
+                    Need need_Hygiene = baby.needs?.AllNeeds.Find(n => n.def == DBHDefOf.Hygiene);
+                    if (need_Hygiene != null)
+                        need_Hygiene.CurLevel = Mathf.Max( 0, need_Hygiene.CurLevel - 0.1f );
+                }
+                if (feeder != baby && Rand.Bool) // 50% chance the feeder gets dirty as well.
+                {
+                    Need need_Hygiene = feeder.needs?.AllNeeds.Find(n => n.def == DBHDefOf.Hygiene);
+                    if (need_Hygiene != null)
+                        need_Hygiene.CurLevel = Mathf.Max( 0, need_Hygiene.CurLevel - 0.1f );
+                }
+            }
         }
     }
 }

--- a/Source/Toddlers/Feeding/FeedingUtility.cs
+++ b/Source/Toddlers/Feeding/FeedingUtility.cs
@@ -32,7 +32,7 @@ namespace Toddlers
             filthRate *= filthFactor;
             if (!(Rand.Value < filthRate * 0.005f))
                 return;
-            if (FilthMaker.TryMakeFilth(feeder.Position, feeder.Map, ThingDefOf.Filth_Trash, baby.LabelIndefinite(), 1))
+            if (FilthMaker.TryMakeFilth(feeder.Position, feeder.Map, Toddlers_DefOf.Toddlers_Filth_Mess, baby.LabelIndefinite(), 1))
                 FilthMonitor.Notify_FilthHumanGenerated();
             if (Toddlers_Mod.DBHLoaded)
             {

--- a/Source/Toddlers/Feeding/Harmony/JobDriver_BottleFeedBaby_FeedBabyFoodFromInventory.cs
+++ b/Source/Toddlers/Feeding/Harmony/JobDriver_BottleFeedBaby_FeedBabyFoodFromInventory.cs
@@ -1,0 +1,24 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using Verse;
+using Verse.AI;
+
+namespace Toddlers
+{
+    // Make toddlers create mess filth when being fed.
+    [HarmonyPatch(typeof(JobDriver_BottleFeedBaby), nameof(JobDriver_BottleFeedBaby.FeedBabyFoodFromInventory))]
+    class JobDriver_BottleFeedBaby_Patch
+    {
+        static Toil Postfix(Toil result, JobDriver_BottleFeedBaby __instance)
+        {
+            Pawn feeder = __instance.pawn;
+            Pawn baby = __instance.Baby;
+            // Make less of a mess than when self-feeding, also adjust for this taking longer than self-feeding.
+            float filthFactor = 1f / 10;
+            if (ToddlerUtility.IsToddler(baby) && feeder.Map != null)
+                result.AddPreTickAction(() => FeedingUtility.TryMakeMessTick(feeder, baby, filthFactor));
+            return result;
+        }
+    }
+}

--- a/Source/Toddlers/Feeding/Harmony/JobDriver_BottleFeedBaby_FeedBabyFoodFromInventory.cs
+++ b/Source/Toddlers/Feeding/Harmony/JobDriver_BottleFeedBaby_FeedBabyFoodFromInventory.cs
@@ -16,7 +16,7 @@ namespace Toddlers
             Pawn baby = __instance.Baby;
             // Make less of a mess than when self-feeding, also adjust for this taking longer than self-feeding.
             float filthFactor = 1f / 10;
-            if (ToddlerUtility.IsToddler(baby) && feeder.Map != null)
+            if (Toddlers_Settings.feedingMakesMess && ToddlerUtility.IsToddler(baby) && feeder.Map != null)
                 result.AddPreTickAction(() => FeedingUtility.TryMakeMessTick(feeder, baby, filthFactor));
             return result;
         }

--- a/Source/Toddlers/Feeding/Harmony/Toils_Ingest_Patch.cs
+++ b/Source/Toddlers/Feeding/Harmony/Toils_Ingest_Patch.cs
@@ -12,7 +12,7 @@ namespace Toddlers
     {
         static Toil Postfix(Toil result, Pawn chewer)
         {
-            if (ToddlerUtility.IsToddler(chewer) && chewer.Map != null)
+            if (Toddlers_Settings.feedingMakesMess && ToddlerUtility.IsToddler(chewer) && chewer.Map != null)
                 result.AddPreTickAction(() => FeedingUtility.TryMakeMessTick(chewer, chewer));
             return result;
         }

--- a/Source/Toddlers/Feeding/Harmony/Toils_Ingest_Patch.cs
+++ b/Source/Toddlers/Feeding/Harmony/Toils_Ingest_Patch.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using Verse;
+using Verse.AI;
+
+namespace Toddlers
+{
+    // Make toddlers create mess filth when feeding themselves.
+    [HarmonyPatch(typeof(Toils_Ingest), nameof(Toils_Ingest.ChewIngestible))]
+    class Toils_Ingest_Patch
+    {
+        static Toil Postfix(Toil result, Pawn chewer)
+        {
+            if (ToddlerUtility.IsToddler(chewer) && chewer.Map != null)
+                result.AddPreTickAction(() => FeedingUtility.TryMakeMessTick(chewer, chewer));
+            return result;
+        }
+    }
+}

--- a/Source/Toddlers/Toddlers_DefOf.cs
+++ b/Source/Toddlers/Toddlers_DefOf.cs
@@ -50,6 +50,7 @@ namespace Toddlers
         //public static ThingDef Apparel_BabyTuque;
         //public static ThingDef Apparel_BabyShadecone;
         public static ThingDef Apparel_BabyTribal;
+        public static ThingDef Toddlers_Filth_Mess;
 
         public static ThoughtDef BabyNoExpectations;
         public static ThoughtDef Toddlers_TraumaticCrash;

--- a/Source/Toddlers/Toddlers_DefOf.cs
+++ b/Source/Toddlers/Toddlers_DefOf.cs
@@ -66,4 +66,15 @@ namespace Toddlers
         public static ThinkTreeDef HumanlikeToddlerConstant;
     }
 
+    [DefOf]
+    public static class DBHDefOf
+    {
+        [MayRequireAnyOf("Dubwise.DubsBadHygiene,Dubwise.DubsBadHygiene.Lite")]
+        public static NeedDef Hygiene;
+
+        static DBHDefOf()
+        {
+            DefOfHelper.EnsureInitializedInCtor(typeof(DBHDefOf));
+        }
+    }
 }

--- a/Source/Toddlers/Toddlers_Settings.cs
+++ b/Source/Toddlers/Toddlers_Settings.cs
@@ -37,6 +37,7 @@ namespace Toddlers
         public static MoveMessageSetting moveMessageSetting = MoveMessageSetting.DangerAndUnknown;
 
         public static bool feedCapableToddlers = true;
+        public static bool feedingMakesMess = true;
 
         public static bool canDraftToddlers = false;
 
@@ -72,6 +73,7 @@ namespace Toddlers
             Scribe_Values.Look(ref careAboutFloorSleep, "careAboutFloorSleep", careAboutFloorSleep, true);
             Scribe_Values.Look(ref moveMessageSetting, "moveMessageSetting", moveMessageSetting, true);
             Scribe_Values.Look(ref feedCapableToddlers, "feedCapableToddlers", feedCapableToddlers, true);
+            Scribe_Values.Look(ref feedingMakesMess, "feedingMakesMess", feedingMakesMess, true);
             Scribe_Values.Look(ref canDraftToddlers, "canDraftToddlers", canDraftToddlers, true);
             Scribe_Values.Look(ref playFallFactor_Baby, "playFallFactor_Baby", playFallFactor_Baby, true);
             Scribe_Values.Look(ref playFallFactor_Toddler, "playFallFactor_Toddler", playFallFactor_Toddler, true);
@@ -118,6 +120,8 @@ namespace Toddlers
                tooltip: "[" + "Default".Translate() + ": " + "On".Translate() + "] " + "SettingTooltipCareAboutFloorSleep".Translate());
             l.CheckboxLabeled("SettingLabelFeedCapableToddlers".Translate() + " :", ref feedCapableToddlers,
                tooltip: "[" + "Default".Translate() + ": " + "On".Translate() + "] " + "SettingTooltipFeedCapableToddlers".Translate());
+            l.CheckboxLabeled("SettingLabelFeedingMakesMess".Translate() + " :", ref feedingMakesMess,
+               tooltip: "[" + "Default".Translate() + ": " + "On".Translate() + "] " + "SettingTooltipFeedingMakesMess".Translate());
             l.CheckboxLabeled("SettingLabelBabyTalk".Translate() + " :", ref toddlerBabyTalk, 
                 tooltip: "[" + "Default".Translate() + ": " + "Off".Translate() + "] " + "SettingTooltipBabyTalk".Translate());
 


### PR DESCRIPTION
Implement #22 making mess when self-feeding or being fed (but not breastfed). Less mess in the latter case. Mess depends on toddler's manipulation. If DBH is present, involved pawns also get hygiene need affected. Configurable.

Possible issues:
- I have made the 'learning manipulation' hediff actually affect manipulation, just like 'learning to walk' affect movement. I could not see any place in the mod that depends on it, so I assume it was an oversight.
- The mess graphic is the splatter image with color based on baby food color. I'm not an artist, that's the best I can do.
- It seems the mod is set up to still build also the 1.5 version, so I have added the filth Def there as well, but I have not actually tested anything with 1.5.
- Made to be fairly messy when self-feeding and clumsy, less so when confident. Getting fed is also less messy, in both cases.
- I'm not a native speaker, so I'm not entirely sure if making the filth label just "mess" is okay, or whether it should be something like "food mess".
