### PR TITLE
make self-feeding slower

### DIFF
--- a/Source/Toddlers/Feeding/FeedingUtility.cs
+++ b/Source/Toddlers/Feeding/FeedingUtility.cs
@@ -12,7 +12,7 @@ namespace Toddlers
 {
     public static class FeedingUtility
     {
-        public const float BASE_MESS_RATE = 0.6f;
+        public const float BASE_MESS_RATE = 0.06f;
 
         public static bool IsToddlerEatingUrgently(Pawn baby)
         {

--- a/Source/Toddlers/Feeding/Harmony/JobDriver_BottleFeedBaby_FeedBabyFoodFromInventory.cs
+++ b/Source/Toddlers/Feeding/Harmony/JobDriver_BottleFeedBaby_FeedBabyFoodFromInventory.cs
@@ -14,11 +14,9 @@ namespace Toddlers
         {
             Pawn feeder = __instance.pawn;
             Pawn baby = __instance.Baby;
-            // Make less of a mess than when self-feeding, also adjust for this taking longer than self-feeding.
-            float filthFactor = 0.1f;
             if (ToddlerUtility.IsToddler(baby) && feeder.Map != null)
             {
-                result.AddPreTickAction(() => FeedingUtility.TryMakeMess(feeder, baby, filthFactor));
+                result.AddPreTickAction(() => FeedingUtility.TryMakeMess(feeder, baby));
             }
                 
             return result;

--- a/Source/Toddlers/Feeding/Harmony/JobDriver_Ingest_Patch.cs
+++ b/Source/Toddlers/Feeding/Harmony/JobDriver_Ingest_Patch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using Verse;
+using Verse.AI;
+
+namespace Toddlers
+{
+    // Make toddlers eat more slowly when they feed themselves,
+    // to roughly match time of getting fed by somebody else.
+    [HarmonyPatch(typeof(JobDriver_Ingest), nameof(JobDriver_Ingest.ChewDurationMultiplier), MethodType.Getter)]
+    class JobDriver_Ingest_Patch
+    {
+        static float Postfix(float result, JobDriver_Ingest __instance)
+        {
+            Pawn pawn = __instance.pawn;
+            if (ToddlerUtility.IsToddler(pawn))
+                result *= 10f;
+            return result;
+        }
+    }
+}

--- a/Source/Toddlers/Feeding/Harmony/Toils_Ingest_Patch.cs
+++ b/Source/Toddlers/Feeding/Harmony/Toils_Ingest_Patch.cs
@@ -14,7 +14,7 @@ namespace Toddlers
         {
             LogUtil.DebugLog($"Toils_Ingest_Patch - chewer: {chewer}, IsToddler: {ToddlerUtility.IsToddler(chewer)}, Map: {chewer.Map}");
             if (ToddlerUtility.IsToddler(chewer) && chewer.Map != null)
-                result.AddPreTickAction(() => FeedingUtility.TryMakeMess(chewer, chewer));
+                result.AddPreTickAction(() => FeedingUtility.TryMakeMess(chewer, chewer, 2));
             return result;
         }
     }

--- a/Source/Toddlers/Toddlers.csproj
+++ b/Source/Toddlers/Toddlers.csproj
@@ -141,6 +141,7 @@
     <Compile Include="MentalStates\BreakExtremeIsImminent_Patch.cs" />
     <Compile Include="Feeding\Harmony\CarryIngestibleToChewSpot_Patch.cs" />
     <Compile Include="Feeding\Harmony\BestFoodSource_Patch.cs" />
+    <Compile Include="Feeding\Harmony\JobDriver_Ingest_Patch.cs" />
     <Compile Include="Carrying\1.5\CarryDownedPawn_Patch.cs" />
     <Compile Include="Carrying\1.5\ForCarry_Patch.cs" />
     <Compile Include="Crib\GetRest_Patch.cs" />


### PR DESCRIPTION
Toddlers use normal ingest code when self-feeding, which is roughly 10x faster than getting fed, which is weird.
